### PR TITLE
Properly shutdown LibertyBans standalone when detecting a shutdown.

### DIFF
--- a/src/main/java/me/dimitri/libertyweb/utils/EventListener.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/EventListener.java
@@ -1,0 +1,19 @@
+package me.dimitri.libertyweb.utils;
+
+import io.micronaut.runtime.server.event.ServerShutdownEvent;
+import jakarta.inject.Inject;
+import me.dimitri.libertyweb.api.LibertyWeb;
+
+public class EventListener {
+
+    @Inject
+    private LibertyWeb libertyWeb;
+
+    @io.micronaut.runtime.event.annotation.EventListener
+    @SuppressWarnings("unused")
+    public void onServerShutDownEvent(ServerShutdownEvent event) {
+        libertyWeb.getBase().shutdown();
+    }
+
+
+}


### PR DESCRIPTION
This PR calls the `BaseFoundation#shutdown()` event, so when shutting down the application, the LibertyBans standalone module can shutdown gracefully.

Since the web application is started with 
```java
Micronaut.build...start()
```
it's only correct to hook into Micronaut for the shutdown process too. This PR uses the `ServerShutdownEvent` which is dispatched by Mikronaut when a shutdown is detected.
