### PR TITLE
Enable self-signed certificate generation, and make it enabled by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,11 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-mysql</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/me/dimitri/libertyweb/Application.java
+++ b/src/main/java/me/dimitri/libertyweb/Application.java
@@ -14,6 +14,8 @@ public class Application {
         if (startupFiles.createConfig()) {
             log.info(" config.yml created, please configure your Liberty Web application there");
             log.info(" Make sure to copy your LibertyBans plugin folder to the same directory as Liberty Web");
+            log.info(" By default self-signed certificate creation is enabled.");
+            log.info(" It is highly recommended that you instead configure a reverse proxy with TLS, and disable ssl in the config.yml file.");
             System.exit(0);
             return;
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,11 @@ micronaut:
   server:
     port: ${server.port}
     host: ${server.host}
+    ssl:
+      enabled: ${server.ssl-enabled}
+      buildSelfSigned: ${server.self-signed-ssl-certificate}
+      dual-protocol: ${server.dual-protocol}
+      http-to-https-redirect: ${server.http-to-https-redirect}
   router:
     static-resources:
       default:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,16 @@ server:
   # On what port the server will run
   port: 8080
   host: "0.0.0.0"
+  # Only enable this if you are generating a self-signed certificate.
+  ssl-enabled: true
+  # Should LiberyWeb generate a self-signed certificate?
+  self-signed-ssl-certificate: true
+  # On what port should we listen for https connections
+  ssl-port: 8433
+  # Should we listen on both http and https?
+  dual-protocol: false
+  # Should LibertyWeb redirect http connections to the https port? Only enable this if you have ssl enabled.
+  http-to-https-redirect: false
 
 # Cache configuration
 caffeine:


### PR DESCRIPTION
This pull request adds the options to generate a Self-Signed SSL certificate, and makes it the default setting.

The reason I created this pull request, is to allow people who didn't, or can't set up a reverse proxy to terminate TLS, a way to encrypt traffic between the clients viewing the web page, and the frontend.

Unfortunately, this PR does come with some downsides:
- The `org.bouncycastle` api has been removed in newer Java versions. The official Mikronaut documentation highlights two ways to work around [this](https://docs.micronaut.io/latest/guide/#https), one of them is adding a dependency, which is the route I took.
- In Mikronaut, for some reason specifying the `key-store` option does not check for the self-signed certificate, at least not in a `.yml` configuration, leading to the inability to use the feature. In code this can be worked around by using a simple boolan expression, but that would require converting this PR into code. And, if I convert this PR to code, a way to access config values dynamically has to be added, since I think people should have the option to disable https handling in Mikronaut all-together.
- Startup times have increased significantly. It seems, that for every restart Mikronaut re-generates the self signed certificate, which takes a significant time. I'm not sure if anything can be done, or maybe, I missed something in AOT.

I'm marking this PR as a Draft, because I would love to hear opinions, and what to improve on.
