### PR TITLE
Add a cache to PunishmentService to speed up API response times.

### DIFF
--- a/src/main/java/me/dimitri/libertyweb/service/PunishmentService.java
+++ b/src/main/java/me/dimitri/libertyweb/service/PunishmentService.java
@@ -26,7 +26,7 @@ public class PunishmentService {
         this.usernameAPI = usernameAPI;
     }
 
-    @CachePut(parameters = {"type"})
+    @Cacheable
     public WebPunishmentResponse getPunishments(String type, String page) {
         int pageNum;
         try { pageNum = Integer.parseInt(page); } catch (NumberFormatException ignored) { return null; }

--- a/src/main/java/me/dimitri/libertyweb/service/PunishmentService.java
+++ b/src/main/java/me/dimitri/libertyweb/service/PunishmentService.java
@@ -1,5 +1,8 @@
 package me.dimitri.libertyweb.service;
 
+import io.micronaut.cache.annotation.CacheConfig;
+import io.micronaut.cache.annotation.CachePut;
+import io.micronaut.cache.annotation.Cacheable;
 import jakarta.inject.Singleton;
 import me.dimitri.libertyweb.api.UsernameAPI;
 import me.dimitri.libertyweb.model.WebPunishment;
@@ -12,6 +15,7 @@ import java.util.List;
 import static me.dimitri.libertyweb.utils.TypeConverter.getType;
 
 @Singleton
+@CacheConfig("requests")
 public class PunishmentService {
     private final PunishmentsRepository punishmentsRepository;
     private final UsernameAPI usernameAPI;
@@ -22,6 +26,7 @@ public class PunishmentService {
         this.usernameAPI = usernameAPI;
     }
 
+    @CachePut(parameters = {"type"})
     public WebPunishmentResponse getPunishments(String type, String page) {
         int pageNum;
         try { pageNum = Integer.parseInt(page); } catch (NumberFormatException ignored) { return null; }

--- a/src/main/java/me/dimitri/libertyweb/service/PunishmentService.java
+++ b/src/main/java/me/dimitri/libertyweb/service/PunishmentService.java
@@ -1,7 +1,6 @@
 package me.dimitri.libertyweb.service;
 
 import io.micronaut.cache.annotation.CacheConfig;
-import io.micronaut.cache.annotation.CachePut;
 import io.micronaut.cache.annotation.Cacheable;
 import jakarta.inject.Singleton;
 import me.dimitri.libertyweb.api.UsernameAPI;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,13 +10,16 @@ micronaut:
         paths: "file:frontend"
   application:
     name: liberty_Web
-  cache:
+  caches:
     caffeine:
       enabled: true
       specs:
         mojang-cache:
           maximum-size: ${caffeine.mojang.maxSize}
           expires-after-write: ${caffeine.mojang.expiration}
+        requests:
+          maximum-size: ${caffeine.requests.maxSize}
+          expires-after-write: ${caffeine.requests.expiration}
 netty:
   default:
     allocator:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,6 @@ caffeine:
     expiration: "10m"
   requests:
     # To avoid re-querying the database for each request, we can cache some.
-    maxSize: 36
+    maxSize: 260
     # After what time the cached requests should expire.
-    expiration: "5m"
+    expiration: "10m"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,7 +14,6 @@ caffeine:
     expiration: "10m"
   requests:
     # To avoid re-querying the database for each request, we can cache some.
-    # Maximum amount of usernames to cache
     maxSize: 36
-    # After what time cache record will expire
+    # After what time the cached requests should expire.
     expiration: "5m"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,3 +12,9 @@ caffeine:
     maxSize: 150
     # After what time cache record will expire
     expiration: "10m"
+  requests:
+    # To avoid re-querying the database for each request, we can cache some.
+    # Maximum amount of usernames to cache
+    maxSize: 36
+    # After what time cache record will expire
+    expiration: "5m"


### PR DESCRIPTION
To my testing, adding a a cache here has improved API request times by a margin. Re-requesting the same data, which you would typically do when navigating on the front end has improved significantly. With the help of the cache, requesting the same data went from averaging ~1s, to averaging ~25ms, which is roughly 40x faster. 