### PR TITLE
Avoid allowing requests with negative page numbers.

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -115,6 +115,10 @@ $(document).ready(function () {
                 return false;
             }
 
+            if (pageCountValue > 999) {
+                return false;
+            }
+
             if (!morePages && pageCountValue > currentPage) {
                 return false;
             }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -59,7 +59,9 @@ $(document).ready(function () {
     });
 
     $('#prevBtn').click(function() {
-        currentPage--;
+        if (currentPage > 1) {
+            currentPage--;
+        }
         fetchPunishments(currentType, currentPage);
     });
 
@@ -97,9 +99,19 @@ $(document).ready(function () {
 
     $('#pageCount').keypress(function(e) {
         if (e.which == 13) {
-            let pageCountValue = $("#pageCount").val() * 1; // Weird way of turning a string into a number, don't ask me why. I'm tired.
+            let pageCountValue = Number($("#pageCount"));
 
+            if (isNaN(pageCountValue)) {
+                return false;
+            }
+
+            // The previous call should ensure that the pageCountValue variable is a number
+            // but leaving this here for safety.
             if (typeof pageCountValue != 'number') {
+                return false;
+            }
+
+            if (pageCountValue < 1) {
                 return false;
             }
 


### PR DESCRIPTION
Previously, it was possible to type a negative integer into the page selection input box, causing an Internal Server Error (500) due to an invalid request. This would get processed on the back end, and would eventually get stopped at [SelectionBuilderBaseImpl#86](https://github.com/A248/LibertyBans/blob/master/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionBuilderBaseImpl.java#L86) with an `java.lang.IllegalArgumentException: Skip count must be non-negative`. 

Additionally, I have added a limit for an upper bound with a value of 999, since that's the max value the input field allows for [here](https://github.com/Dimitri-Bit/Liberty-Bans-Web/blob/main/frontend/index.html#L99).