### PR TITLE
Add custom error handling to increase stability.

### DIFF
--- a/src/main/java/me/dimitri/libertyweb/Application.java
+++ b/src/main/java/me/dimitri/libertyweb/Application.java
@@ -1,8 +1,6 @@
 package me.dimitri.libertyweb;
 
 import io.micronaut.runtime.Micronaut;
-import jakarta.inject.Inject;
-import me.dimitri.libertyweb.api.LibertyWeb;
 import me.dimitri.libertyweb.utils.StartupFiles;
 import me.dimitri.libertyweb.utils.exception.FileWorkerException;
 import org.slf4j.Logger;
@@ -29,7 +27,9 @@ public class Application {
                 log.info(" database, this will improve overall security and make logging database connections easier.");
             }
         } catch (FileWorkerException e) {
-            log.error(e.toString());
+            log.error(e.getMessage());
+            System.exit(0);
+            return;
         }
         System.setProperty("micronaut.config.files", "config.yml");
         Micronaut.build(args).banner(false).start();

--- a/src/main/java/me/dimitri/libertyweb/Application.java
+++ b/src/main/java/me/dimitri/libertyweb/Application.java
@@ -4,6 +4,7 @@ import io.micronaut.runtime.Micronaut;
 import jakarta.inject.Inject;
 import me.dimitri.libertyweb.api.LibertyWeb;
 import me.dimitri.libertyweb.utils.StartupFiles;
+import me.dimitri.libertyweb.utils.exception.FileWorkerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,18 +14,22 @@ public class Application {
 
     public static void main(String[] args) {
         StartupFiles startupFiles = new StartupFiles();
-        if (startupFiles.createConfig()) {
-            log.info(" config.yml created, please configure your Liberty Web application there");
-            log.info(" Make sure to copy your LibertyBans plugin folder to the same directory as Liberty Web");
-            System.exit(0);
-            return;
-        }
-        if (startupFiles.createFrontend()) {
-            log.info(" Frontend files for the website have been created, if you wish to edit");
-            log.info(" the look of your website you can do so in the \"frontend\" folder located");
-            log.info(" in the same directory as your application jar file.");
-            log.info(" It is recommended to create a new user that has read-only access to your punishments");
-            log.info(" database, this will improve overall security and make logging database connections easier.");
+        try {
+            if (startupFiles.createConfig()) {
+                log.info(" config.yml created, please configure your Liberty Web application there");
+                log.info(" Make sure to copy your LibertyBans plugin folder to the same directory as Liberty Web");
+                System.exit(0);
+                return;
+            }
+            if (startupFiles.createFrontend()) {
+                log.info(" Frontend files for the website have been created, if you wish to edit");
+                log.info(" the look of your website you can do so in the \"frontend\" folder located");
+                log.info(" in the same directory as your application jar file.");
+                log.info(" It is recommended to create a new user that has read-only access to your punishments");
+                log.info(" database, this will improve overall security and make logging database connections easier.");
+            }
+        } catch (FileWorkerException e) {
+            log.error(e.toString());
         }
         System.setProperty("micronaut.config.files", "config.yml");
         Micronaut.build(args).banner(false).start();

--- a/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
+++ b/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
@@ -34,14 +34,14 @@ public class UsernameAPI {
         try {
             json = requestUtil.get(MOJANG_URL + uuid);
         } catch (HttpErrorException e) {
-            log.error(e.toString());
+            log.error(e.getMessage());
         }
 
         if (json == null) {
             try {
                 json = requestUtil.get(CRAFTHEAD_URL + uuid);
             } catch (HttpErrorException e) {
-                log.error(e.toString());
+                log.error(e.getMessage());
             }
         }
 
@@ -56,7 +56,7 @@ public class UsernameAPI {
         try {
             return objectMapper.readTree(json);
         } catch (IOException e) {
-            log.error(e.toString());
+            log.error(e.getMessage());
         }
         return null;
     }

--- a/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
+++ b/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
@@ -26,10 +26,8 @@ public class UsernameAPI {
 
     @Cacheable("mojang-cache")
     public String usernameLookup(String uuid) {
-        String json;
-        
         try {
-            json = requestUtil.get(MOJANG_URL + uuid);
+            String json = requestUtil.get(MOJANG_URL + uuid);
 
             if (json == null) {
                 json = requestUtil.get(CRAFTHEAD_URL + uuid);
@@ -42,7 +40,6 @@ public class UsernameAPI {
         } catch (HttpErrorException e) {
             return "Unknown";
         }
-
         return "Unknown";
     }
 

--- a/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
+++ b/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
@@ -6,6 +6,7 @@ import io.micronaut.cache.annotation.Cacheable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import me.dimitri.libertyweb.utils.HttpRequestUtil;
+import me.dimitri.libertyweb.utils.exception.HttpErrorException;
 
 import java.io.IOException;
 
@@ -25,11 +26,19 @@ public class UsernameAPI {
 
     @Cacheable("mojang-cache")
     public String usernameLookup(String uuid) {
-        String json = requestUtil.get(MOJANG_URL + uuid);
+        String json;
 
-        if (json == null) {
-            json = requestUtil.get(CRAFTHEAD_URL + uuid);
+        try {
+            json = requestUtil.get(MOJANG_URL + uuid);
+
+            if (json == null) {
+                json = requestUtil.get(CRAFTHEAD_URL + uuid);
+            }
+
+        } catch (HttpErrorException e) {
+            json = null;
         }
+
         if (json != null) {
             JsonNode jsonNode = parseJson(json);
             return getUsername(jsonNode);

--- a/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
+++ b/src/main/java/me/dimitri/libertyweb/api/UsernameAPI.java
@@ -27,7 +27,7 @@ public class UsernameAPI {
     @Cacheable("mojang-cache")
     public String usernameLookup(String uuid) {
         String json;
-
+        
         try {
             json = requestUtil.get(MOJANG_URL + uuid);
 
@@ -35,14 +35,14 @@ public class UsernameAPI {
                 json = requestUtil.get(CRAFTHEAD_URL + uuid);
             }
 
+            if (json != null) {
+                JsonNode jsonNode = parseJson(json);
+                return getUsername(jsonNode);
+            }
         } catch (HttpErrorException e) {
-            json = null;
+            return "Unknown";
         }
 
-        if (json != null) {
-            JsonNode jsonNode = parseJson(json);
-            return getUsername(jsonNode);
-        }
         return "Unknown";
     }
 

--- a/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java
@@ -29,7 +29,7 @@ public class HttpRequestUtil {
                 return response.body();
             }
         } catch (IOException | InterruptedException e) {
-            throw new HttpErrorException("Unable to get request from " + url, e.getCause());
+            throw new HttpErrorException("Unable to get request from " + url, e);
         }
         return null;
     }

--- a/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java
@@ -29,7 +29,7 @@ public class HttpRequestUtil {
                 return response.body();
             }
         } catch (IOException | InterruptedException e) {
-            throw new HttpErrorException("Unable to get request from " + url, e);
+            throw new HttpErrorException("Unable to get request from " + url, e.getCause());
         }
         return null;
     }

--- a/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java
@@ -2,6 +2,7 @@ package me.dimitri.libertyweb.utils;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import me.dimitri.libertyweb.utils.exception.HttpErrorException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -19,7 +20,7 @@ public class HttpRequestUtil {
         client = HttpClient.newHttpClient();
     }
 
-    public String get(String url) {
+    public String get(String url) throws HttpErrorException {
         try {
             URI uri = URI.create(url);
             HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
@@ -28,7 +29,7 @@ public class HttpRequestUtil {
                 return response.body();
             }
         } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new HttpErrorException("Unable to get request from " + url, e);
         }
         return null;
     }

--- a/src/main/java/me/dimitri/libertyweb/utils/StartupFiles.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/StartupFiles.java
@@ -1,5 +1,6 @@
 package me.dimitri.libertyweb.utils;
 
+import me.dimitri.libertyweb.utils.exception.FileWorkerException;
 import net.lingala.zip4j.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
 
@@ -18,7 +19,7 @@ public class StartupFiles {
         this(null);
     }
 
-    public boolean createConfig() {
+    public boolean createConfig() throws FileWorkerException {
         try {
             File config = new File(rootPath, "config.yml");
             if (config.createNewFile()) {
@@ -27,12 +28,12 @@ public class StartupFiles {
                 return true;
             }
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new FileWorkerException("Unable to create frontend config: ", e.getCause());
         }
         return false;
     }
 
-    public boolean createFrontend() {
+    public boolean createFrontend() throws FileWorkerException {
         try {
             File frontend = new File(rootPath, "frontend");
             if (!frontend.isDirectory()) {
@@ -45,18 +46,18 @@ public class StartupFiles {
                 return true;
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new FileWorkerException("Unable to create frontend files: ", e.getCause());
         }
         return false;
     }
 
-    private void unzip(File file) {
+    private void unzip(File file) throws FileWorkerException {
         try {
             ZipFile zipFile = new ZipFile(file);
             zipFile.extractAll(getFilePath());
             file.delete();
         } catch (ZipException | URISyntaxException e) {
-            throw new RuntimeException(e);
+            throw new FileWorkerException("Unable to unzip " + file, e.getCause());
         }
     }
 

--- a/src/main/java/me/dimitri/libertyweb/utils/StartupFiles.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/StartupFiles.java
@@ -28,7 +28,7 @@ public class StartupFiles {
                 return true;
             }
         } catch (IOException e) {
-            throw new FileWorkerException("Unable to create frontend config: ", e.getCause());
+            throw new FileWorkerException("Unable to create config: ", e.getCause());
         }
         return false;
     }
@@ -46,7 +46,7 @@ public class StartupFiles {
                 return true;
             }
         } catch (Exception e) {
-            throw new FileWorkerException("Unable to create frontend files: ", e.getCause());
+            throw new FileWorkerException("Unable to create frontend files: ", e);
         }
         return false;
     }
@@ -57,7 +57,7 @@ public class StartupFiles {
             zipFile.extractAll(getFilePath());
             file.delete();
         } catch (ZipException | URISyntaxException e) {
-            throw new FileWorkerException("Unable to unzip " + file, e.getCause());
+            throw new FileWorkerException("Unable to unzip " + file, e);
         }
     }
 

--- a/src/main/java/me/dimitri/libertyweb/utils/exception/FileWorkerException.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/exception/FileWorkerException.java
@@ -1,0 +1,7 @@
+package me.dimitri.libertyweb.utils.exception;
+
+public class FileWorkerException extends Exception {
+    public FileWorkerException(String msg, Throwable throwable) {
+        super(msg, throwable);
+    }
+}

--- a/src/main/java/me/dimitri/libertyweb/utils/exception/HttpErrorException.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/exception/HttpErrorException.java
@@ -1,0 +1,7 @@
+package me.dimitri.libertyweb.utils.exception;
+
+public class HttpErrorException extends Exception {
+    public HttpErrorException(String exceptionMsg, Exception e) {
+        super(exceptionMsg, e);
+    }
+}

--- a/src/main/java/me/dimitri/libertyweb/utils/exception/HttpErrorException.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/exception/HttpErrorException.java
@@ -1,7 +1,7 @@
 package me.dimitri.libertyweb.utils.exception;
 
-public class HttpErrorException extends Exception {
-    public HttpErrorException(String exceptionMsg, Exception e) {
-        super(exceptionMsg, e);
+public class HttpErrorException extends RuntimeException {
+    public HttpErrorException(String exceptionMsg, Throwable throwable) {
+        super(exceptionMsg, throwable);
     }
 }

--- a/src/main/java/me/dimitri/libertyweb/utils/exception/HttpErrorException.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/exception/HttpErrorException.java
@@ -1,7 +1,7 @@
 package me.dimitri.libertyweb.utils.exception;
 
-public class HttpErrorException extends RuntimeException {
-    public HttpErrorException(String exceptionMsg, Throwable throwable) {
-        super(exceptionMsg, throwable);
+public class HttpErrorException extends Exception {
+    public HttpErrorException(String msg, Throwable throwable) {
+        super(msg, throwable);
     }
 }


### PR DESCRIPTION
In LibertyWeb's `HttpRequestUtil.java`, previously, a `RuntimeException` was thrown [here](https://github.com/Dimitri-Bit/Liberty-Bans-Web/blob/main/src/main/java/me/dimitri/libertyweb/utils/HttpRequestUtil.java#L31), whenever a request failed. This method is used in `UsernameApi.java`, to resolve to a username. However if this failed, due to the previously thrown `RuntimeException`, this could result in the json object not being set, or possibly the thread hanging, and leaving the application in a hanging state, where the front end would be uninteractable. 

To reproduce the issue, add the following lines to your `hosts` file:
```
0.0.0.0 api.minecraftservices.com
0.0.0.0 crafthead.net
```
Then, open the LibertyWeb interface, with a populated database.

This PR aims to solve this by removing the `RuntimeException` from methods, and instead, throw a custom exception, namely `HttpErrorException` at the well methods, and log them at the callers. This is friendlier for the end user, and avoids issues brought up by using `RuntimeException`. Using `RuntimeException`, I think is fine, since these can only be caught during runtime, but custom exception handling provides the benefit of stability.

I have also removed other uses of the exception from the code base, and replaced them with `FileWorkerException`. Here, there is no particular reason why `RuntimeException` wouldn't work, but I thought it would look prettier. In case this is un-needed, I'm more than happy to adjust as per requested.

