### PR TITLE
Show more details for punishments.

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -136,11 +136,17 @@ input[type=number] {
 }
 
 .light-row {
-  background-color: var(--dark-gray);
+  background-color: var(--gray-secondary);
 }
 
 .permanent-line {
   border-left: 7px solid var(--red);
+  height: 8vh;
+  padding: 1vh;
+}
+
+.permanent-line-right {
+  border-right: 7px solid var(--red);
   height: 8vh;
   padding: 1vh;
 }
@@ -151,7 +157,19 @@ input[type=number] {
   padding: 1vh;
 }
 
+.active-line-right {
+  border-right: 7px solid var(--yellow);
+  height: 8vh;
+  padding: 1vh;
+}
+
 .expired-line {
+  border-left: 7px solid var(--green);
+  height: 8vh;
+  padding: 1vh;
+}
+
+.expired-line-right {
   border-left: 7px solid var(--green);
   height: 8vh;
   padding: 1vh;
@@ -185,6 +203,12 @@ input[type=number] {
   background-color: var(--black-row);
   color: var(--gray-primary);
   /* border-radius: 5px; */
+  .fa-info-circle { color: var(--gray-primary)}
+  .fa-info-circle { background-color: var(--black-primary)}
+  .punishment-button { background-color: var(--black-primary)}
+  .punishment-button { border-color: var(--bs-white)}
+  .punishment-button { box-shadow: none }
+  .punishment-button:focus { box-shadow: none }
 }
 
 .category-text {
@@ -195,6 +219,11 @@ input[type=number] {
 
 .punishment-info {
   background-color: var(--black-row);
+  color: var(--gray-primary);
+  .card { background-color: var(--other); }
+  .card p { margin: 0; }
+  .card { padding: 1vh; }
+  .card-header { border-bottom: 1px solid var(--gray-primary); }
 }
 
 /* Navigation Modal */

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -170,7 +170,7 @@ input[type=number] {
 }
 
 .expired-line-right {
-  border-left: 7px solid var(--green);
+  border-right: 7px solid var(--green);
   height: 8vh;
   padding: 1vh;
 }
@@ -203,12 +203,6 @@ input[type=number] {
   background-color: var(--black-row);
   color: var(--gray-primary);
   /* border-radius: 5px; */
-  .fa-info-circle { color: var(--gray-primary)}
-  .fa-info-circle { background-color: var(--black-primary)}
-  .punishment-button { background-color: var(--black-primary)}
-  .punishment-button { border-color: var(--bs-white)}
-  .punishment-button { box-shadow: none }
-  .punishment-button:focus { box-shadow: none }
 }
 
 .category-text {
@@ -218,12 +212,19 @@ input[type=number] {
 }
 
 .punishment-info {
-  background-color: var(--black-row);
   color: var(--gray-primary);
   .card { background-color: var(--other); }
   .card p { margin: 0; }
-  .card { padding: 1vh; }
   .card-header { border-bottom: 1px solid var(--gray-primary); }
+}
+
+.button-row {
+  .fa-info-circle { color: var(--gray-primary)}
+  .fa-info-circle { background-color: var(--black-primary)}
+  .punishment-button { background-color: var(--black-primary)}
+  .punishment-button { border-color: var(--bs-white)}
+  .punishment-button { box-shadow: none }
+  .punishment-button:focus { box-shadow: none }
 }
 
 /* Navigation Modal */

--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -139,7 +139,7 @@ input[type=number] {
   background-color: var(--gray-secondary);
 }
 
-.permanent-line {
+.permanent-line-left {
   border-left: 7px solid var(--red);
   height: 8vh;
   padding: 1vh;
@@ -151,7 +151,7 @@ input[type=number] {
   padding: 1vh;
 }
 
-.active-line {
+.active-line.left {
   border-left: 7px solid var(--yellow);
   height: 8vh;
   padding: 1vh;
@@ -163,7 +163,7 @@ input[type=number] {
   padding: 1vh;
 }
 
-.expired-line {
+.expired-line-left {
   border-left: 7px solid var(--green);
   height: 8vh;
   padding: 1vh;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -105,7 +105,7 @@
                     <div class="col">
                         <div class="collapse" id="punishment-0-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Start date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-start-date-0">2025.04.27</p>
                                 </div>
@@ -115,7 +115,7 @@
                     <div class="col">
                         <div class="collapse" id="punishment-0-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expiration date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-end-date-0">2025.04.27</p>
                                 </div>
@@ -125,7 +125,7 @@
                     <div class="col">
                         <div class="collapse" id="punishment-0-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
                                     <p id="punishment-expire-date-0">2025.04.27</p>
                                 </div>
@@ -176,7 +176,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-1-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Start date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-start-date-1">2025.04.27</p>
                                 </div>
@@ -186,7 +186,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-1-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expiration date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-end-date-1">2025.04.27</p>
                                 </div>
@@ -196,7 +196,7 @@
                     <div class="col">
                         <div class="collapse collaps" id="punishment-1-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
                                     <p id="punishment-expire-date-1">2025.04.27</p>
                                 </div>
@@ -247,7 +247,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-2-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Start date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-start-date-2">2025.04.27</p>
                                 </div>
@@ -257,7 +257,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-2-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expiration date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-end-date-2">2025.04.27</p>
                                 </div>
@@ -267,7 +267,7 @@
                     <div class="col">
                         <div class="collapse collaps" id="punishment-2-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
                                     <p id="punishment-expire-date-2">2025.04.27</p>
                                 </div>
@@ -318,7 +318,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-3-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Start date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-start-date-3">2025.04.27</p>
                                 </div>
@@ -328,7 +328,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-3-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expiration date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-end-date-3">2025.04.27</p>
                                 </div>
@@ -338,7 +338,7 @@
                     <div class="col">
                         <div class="collapse collaps" id="punishment-3-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
                                     <p id="punishment-expire-date-3">2025.04.27</p>
                                 </div>
@@ -389,7 +389,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-4-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Start date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-start-date-4">2025.04.27</p>
                                 </div>
@@ -399,7 +399,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-4-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expiration date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-end-date-4">2025.04.27</p>
                                 </div>
@@ -409,7 +409,7 @@
                     <div class="col">
                         <div class="collapse collaps" id="punishment-4-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
                                     <p id="punishment-expire-date-4">2025.04.27</p>
                                 </div>
@@ -460,7 +460,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-5-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Start date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-start-date-5">2025.04.27</p>
                                 </div>
@@ -470,7 +470,7 @@
                     <div class="col">
                         <div class=collapse id="punishment-5-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expiration date:</h5>
                                 <div class="card-body">
                                     <p id="punishment-end-date-5">2025.04.27</p>
                                 </div>
@@ -480,7 +480,7 @@
                     <div class="col">
                         <div class="collapse collaps" id="punishment-5-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
                                     <p id="punishment-expire-date-5">2025.04.27</p>
                                 </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -133,7 +133,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#punishment-0-collapse-0, #punishment-0-collapse-1, #punishment-0-collapse-2"
@@ -204,7 +204,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#punishment-1-collapse-0, #punishment-1-collapse-1, #punishment-1-collapse-2"
@@ -275,7 +275,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#punishment-2-collapse-0, #punishment-2-collapse-1, #punishment-2-collapse-2"
@@ -346,7 +346,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#punishment-3-collapse-0, #punishment-3-collapse-1, #punishment-3-collapse-2"
@@ -417,7 +417,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#punishment-4-collapse-0, #punishment-4-collapse-1, #punishment-4-collapse-2"
@@ -488,7 +488,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
                                 data-bs-target="#punishment-5-collapse-0, #punishment-5-collapse-1, #punishment-5-collapse-2"
@@ -500,14 +500,18 @@
                 </div>
             </div>
         </div>
-        <div id="nothing-to-show" class="text-center p-5">
-            <p class="fw-medium fs-5 mb-0">Nothing to show for now</p>
+        <div>
+            <div id="nothing-to-show" class="text-center p-5">
+                <p class="fw-medium fs-5 mb-0">Nothing to show for now</p>
+            </div>
         </div>
-        <div class="d-flex justify-content-center">
-            <button class="previous-btn p-2 mx-1" id="prevBtn">Previous</button>
-            <input class="page-count text-center" type="number" id="pageCount" name="page-count" min="1" max="999" size="4">
-            <button class="next-btn p-2 mx-1" id="nextBtn">Next</button>
-            <div id="view-punishments"></div>
+        <div>
+            <div class="d-flex justify-content-center">
+                <button class="previous-btn p-2 mx-1" id="prevBtn">Previous</button>
+                <input class="page-count text-center" type="number" id="pageCount" name="page-count" min="1" max="999" size="4">
+                <button class="next-btn p-2 mx-1" id="nextBtn">Next</button>
+                <div id="view-punishments"></div>
+            </div>
         </div>
     </div>
 </section>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -99,9 +99,11 @@
                     </div>
                     <div id="line-below-0" class="col-auto"></div>
                 </div>
+            </div>
+            <div id="punishments-info-0">
                 <div class="row punishment-info flex-nowrap">
                     <div class="col">
-                        <div class="collapse punishment-0-collapse-0" id="punishments-0-collapse-0-arial">
+                        <div class="collapse" id="punishment-0-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -111,7 +113,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse punishment-0-collapse-1" id="punishments-0-collapse-1-arial">
+                        <div class="collapse" id="punishment-0-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -121,7 +123,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collapse punishment-0-collapse-2" id="punishments-0-collapse-2-arial">
+                        <div class="collapse" id="punishment-0-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -134,9 +136,9 @@
                 <div class="row align-items-center p-3 flex-nowrap punishment-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="punishment-0-collapse-0, punishment-0-collapse-1, punishment-0-collapse-2"
+                                data-bs-target="#punishment-0-collapse-0, #punishment-0-collapse-1, #punishment-0-collapse-2"
                                 aria-expanded="false"
-                                aria-controls="punishments-0-collapse-0-arial punishments-0-collapse-1-arial punishments-0-collapse-1-arial">
+                                aria-controls="punishment-0-collapse-0, punishment-0-collapse-1, punishment-0-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
                         </button>
                     </div>
@@ -168,9 +170,11 @@
                     </div>
                     <div id="line-below-1" class="col-auto"></div>
                 </div>
+            </div>
+            <div id="punishments-info-1">
                 <div class="row punishment-info flex-nowrap">
                     <div class="col">
-                        <div class="collapse punishment-1-collapse-0" id="punishments-1-collapse-0-arial">
+                        <div class=collapse id="punishment-1-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -180,7 +184,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse punishment-1-collapse-1" id="punishments-1-collapse-1-arial">
+                        <div class=collapse id="punishment-1-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -190,7 +194,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collapse punishment-1-collapse-2" id="punishments-1-collapse-2-arial">
+                        <div class="collapse collaps" id="punishment-1-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -203,9 +207,9 @@
                 <div class="row align-items-center p-3 flex-nowrap punishment-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="punishment-1-collapse-0, punishment-1-collapse-1, punishment-1-collapse-2"
+                                data-bs-target="#punishment-1-collapse-0, #punishment-1-collapse-1, #punishment-1-collapse-2"
                                 aria-expanded="false"
-                                aria-controls="punishments-1-collapse-0-arial punishments-1-collapse-1-arial punishments-1-collapse-1-arial">
+                                aria-controls="punishment-1-collapse-0, punishment-1-collapse-1, punishment-1-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
                         </button>
                     </div>
@@ -237,9 +241,11 @@
                     </div>
                     <div id="line-below-2" class="col-auto"></div>
                 </div>
+            </div>
+            <div id="punishments-info-2">
                 <div class="row punishment-info flex-nowrap">
                     <div class="col">
-                        <div class="collapse punishment-2-collapse-0" id="punishments-2-collapse-0-arial">
+                        <div class=collapse id="punishment-2-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -249,7 +255,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse punishment-2-collapse-1" id="punishments-2-collapse-1-arial">
+                        <div class=collapse id="punishment-2-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -259,7 +265,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collapse punishment-2-collapse-2" id="punishments-2-collapse-2-arial">
+                        <div class="collapse collaps" id="punishment-2-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -272,9 +278,9 @@
                 <div class="row align-items-center p-3 flex-nowrap punishment-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="punishment-2-collapse-0, punishment-2-collapse-1, punishment-2-collapse-2"
+                                data-bs-target="#punishment-2-collapse-0, #punishment-2-collapse-1, #punishment-2-collapse-2"
                                 aria-expanded="false"
-                                aria-controls="punishments-2-collapse-0-arial punishments-2-collapse-1-arial punishments-2-collapse-1-arial">
+                                aria-controls="punishment-2-collapse-0, punishment-2-collapse-1, punishment-2-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
                         </button>
                     </div>
@@ -306,9 +312,11 @@
                     </div>
                     <div id="line-below-3" class="col-auto"></div>
                 </div>
+            </div>
+            <div id="punishments-info-3">
                 <div class="row punishment-info flex-nowrap">
                     <div class="col">
-                        <div class="collapse punishment-3-collapse-0" id="punishments-3-collapse-0-arial">
+                        <div class=collapse id="punishment-3-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -318,7 +326,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse punishment-0-collapse-1" id="punishments-3-collapse-1-arial">
+                        <div class=collapse id="punishment-3-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -328,7 +336,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collapse punishment-0-collapse-2" id="punishments-3-collapse-2-arial">
+                        <div class="collapse collaps" id="punishment-3-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -341,9 +349,9 @@
                 <div class="row align-items-center p-3 flex-nowrap punishment-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="punishment-3-collapse-0, punishment-3-collapse-1, punishment-3-collapse-2"
+                                data-bs-target="#punishment-3-collapse-0, #punishment-3-collapse-1, #punishment-3-collapse-2"
                                 aria-expanded="false"
-                                aria-controls="punishments-3-collapse-0-arial punishments-3-collapse-1-arial punishments-3-collapse-1-arial">
+                                aria-controls="punishment-3-collapse-0, punishment-3-collapse-1, punishment-3-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
                         </button>
                     </div>
@@ -375,9 +383,11 @@
                     </div>
                     <div id="line-below-4" class="col-auto"></div>
                 </div>
+            </div>
+            <div id="punishments-info-4">
                 <div class="row punishment-info flex-nowrap">
                     <div class="col">
-                        <div class="collapse punishment-4-collapse-0" id="punishments-4-collapse-0-arial">
+                        <div class=collapse id="punishment-4-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -387,7 +397,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse punishment-4-collapse-1" id="punishments-4-collapse-1-arial">
+                        <div class=collapse id="punishment-4-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -397,7 +407,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collapse punishment-4-collapse-2" id="punishments-4-collapse-2-arial">
+                        <div class="collapse collaps" id="punishment-4-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -410,9 +420,9 @@
                 <div class="row align-items-center p-3 flex-nowrap punishment-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="punishment-4-collapse-0, punishment-4-collapse-1, punishment-4-collapse-2"
+                                data-bs-target="#punishment-4-collapse-0, #punishment-4-collapse-1, #punishment-4-collapse-2"
                                 aria-expanded="false"
-                                aria-controls="punishments-4-collapse-0-arial punishments-4-collapse-1-arial punishments-4-collapse-1-arial">
+                                aria-controls="punishment-4-collapse-0, punishment-4-collapse-1, punishment-4-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
                         </button>
                     </div>
@@ -444,9 +454,11 @@
                     </div>
                     <div id="line-below-5" class="col-auto"></div>
                 </div>
+            </div>
+            <div id="punishments-info-5">
                 <div class="row punishment-info flex-nowrap">
                     <div class="col">
-                        <div class="collapse punishment-5-collapse-0" id="punishments-5-collapse-0-arial">
+                        <div class=collapse id="punishment-5-collapse-0">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -456,7 +468,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse punishment-5-collapse-1" id="punishments-5-collapse-1-arial">
+                        <div class=collapse id="punishment-5-collapse-1">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -466,7 +478,7 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collapse punishment-5-collapse-2" id="punishments-5-collapse-2-arial">
+                        <div class="collapse collaps" id="punishment-5-collapse-2">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                                 <div class="card-body">
@@ -479,22 +491,21 @@
                 <div class="row align-items-center p-3 flex-nowrap punishment-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="punishment-5-collapse-0, punishment-5-collapse-1, punishment-5-collapse-2"
+                                data-bs-target="#punishment-5-collapse-0, #punishment-5-collapse-1, #punishment-5-collapse-2"
                                 aria-expanded="false"
-                                aria-controls="punishments-5-collapse-0-arial punishments-5-collapse-1-arial punishments-5-collapse-1-arial">
+                                aria-controls="punishment-5-collapse-0, punishment-5-collapse-1, punishment-5-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
                         </button>
                     </div>
                 </div>
             </div>
-            <div id="nothing-to-show" class="text-center p-5">
-                <p class="fw-medium fs-5 mb-0">Nothing to show for now</p>
-            </div>
+        </div>
+        <div id="nothing-to-show" class="text-center p-5">
+            <p class="fw-medium fs-5 mb-0">Nothing to show for now</p>
         </div>
         <div class="d-flex justify-content-center">
             <button class="previous-btn p-2 mx-1" id="prevBtn">Previous</button>
-            <input class="page-count text-center" type="number" id="pageCount" name="page-count" min="1" max="999"
-                   size="4">
+            <input class="page-count text-center" type="number" id="pageCount" name="page-count" min="1" max="999" size="4">
             <button class="next-btn p-2 mx-1" id="nextBtn">Next</button>
             <div id="view-punishments"></div>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -123,7 +123,17 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse" id="punishment-0-collapse-2">
+                        <div class=collapse id="punishment-0-collapse-2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Length:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-length-0">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse" id="punishment-0-collapse-3">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
@@ -136,7 +146,7 @@
                 <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#punishment-0-collapse-0, #punishment-0-collapse-1, #punishment-0-collapse-2"
+                                data-bs-target="#punishment-0-collapse-0, #punishment-0-collapse-1, #punishment-0-collapse-2, #punishment-0-collapse-3"
                                 aria-expanded="false"
                                 aria-controls="punishment-0-collapse-0, punishment-0-collapse-1, punishment-0-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
@@ -194,7 +204,17 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collaps" id="punishment-1-collapse-2">
+                        <div class=collapse id="punishment-1-collapse-2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Length:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-length-1">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collaps" id="punishment-1-collapse-3">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
@@ -207,7 +227,7 @@
                 <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#punishment-1-collapse-0, #punishment-1-collapse-1, #punishment-1-collapse-2"
+                                data-bs-target="#punishment-1-collapse-0, #punishment-1-collapse-1, #punishment-1-collapse-2, #punishment-1-collapse-3"
                                 aria-expanded="false"
                                 aria-controls="punishment-1-collapse-0, punishment-1-collapse-1, punishment-1-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
@@ -265,7 +285,17 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collaps" id="punishment-2-collapse-2">
+                        <div class=collapse id="punishment-2-collapse-2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Length:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-length-2">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse" id="punishment-2-collapse-3">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
@@ -278,7 +308,7 @@
                 <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#punishment-2-collapse-0, #punishment-2-collapse-1, #punishment-2-collapse-2"
+                                data-bs-target="#punishment-2-collapse-0, #punishment-2-collapse-1, #punishment-2-collapse-2, #punishment-2-collapse-3"
                                 aria-expanded="false"
                                 aria-controls="punishment-2-collapse-0, punishment-2-collapse-1, punishment-2-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
@@ -336,7 +366,17 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collaps" id="punishment-3-collapse-2">
+                        <div class=collapse id="punishment-3-collapse-2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Length:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-length-3">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collaps" id="punishment-3-collapse-3">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
@@ -349,7 +389,7 @@
                 <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#punishment-3-collapse-0, #punishment-3-collapse-1, #punishment-3-collapse-2"
+                                data-bs-target="#punishment-3-collapse-0, #punishment-3-collapse-1, #punishment-3-collapse-2, #punishment-3-collapse-3"
                                 aria-expanded="false"
                                 aria-controls="punishment-3-collapse-0, punishment-3-collapse-1, punishment-3-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
@@ -407,7 +447,17 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collaps" id="punishment-4-collapse-2">
+                        <div class=collapse id="punishment-4-collapse-2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Length:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-length-4">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collaps" id="punishment-4-collapse-3">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
@@ -420,7 +470,7 @@
                 <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#punishment-4-collapse-0, #punishment-4-collapse-1, #punishment-4-collapse-2"
+                                data-bs-target="#punishment-4-collapse-0, #punishment-4-collapse-1, #punishment-4-collapse-2, #punishment-4-collapse-3"
                                 aria-expanded="false"
                                 aria-controls="punishment-4-collapse-0, punishment-4-collapse-1, punishment-4-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>
@@ -478,7 +528,17 @@
                         </div>
                     </div>
                     <div class="col">
-                        <div class="collapse collaps" id="punishment-5-collapse-2">
+                        <div class=collapse id="punishment-5-collapse-2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Length:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-length-5">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collaps" id="punishment-5-collapse-3">
                             <div class="card text-bg-dark mb-3 text-center">
                                 <h5 class="card-header fs-5 mb-0">Expires in:</h5>
                                 <div class="card-body">
@@ -491,7 +551,7 @@
                 <div class="row align-items-center p-3 flex-nowrap button-row">
                     <div class="d-flex justify-content-center">
                         <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#punishment-5-collapse-0, #punishment-5-collapse-1, #punishment-5-collapse-2"
+                                data-bs-target="#punishment-5-collapse-0, #punishment-5-collapse-1, #punishment-5-collapse-2, #punishment-5-collapse-3"
                                 aria-expanded="false"
                                 aria-controls="punishment-5-collapse-0, punishment-5-collapse-1, punishment-5-collapse-2">
                             <i class="fa fa-info-circle fa-w-16"></i>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <!-- Font Awesome -->
     <script src="/js/vendor/fontawesome.min.js"></script>
     <!-- Bootstrap -->
-    <link rel="stylesheet" href="/css/vendor/bootstrap.min.css" />
+    <link rel="stylesheet" href="/css/vendor/bootstrap.min.css"/>
     <script src="/js/vendor/bootstrap.bundle.min.js"></script>
     <!-- JQuery -->
     <script src="/js/vendor/jquery.js"></script>
@@ -21,55 +21,57 @@
 </head>
 <body>
 
-    <!-- Navbar -->
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-darker py-2 sticky-top">
-      <div class="container-fluid mx-4">
+<!-- Navbar -->
+<nav class="navbar navbar-expand-lg navbar-dark navbar-darker py-2 sticky-top">
+    <div class="container-fluid mx-4">
         <span class="navbar-brand">
           <small>LibertyBans</small>
         </span>
-        
-        <button class="navbar-toggle-btn-mobile d-lg-none" id="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-          <i class="fas fa-sliders-h"></i>
-        </button>
-        
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-            <li class="nav-item navbar-active pe-1">
-              <a href="javascript:;" class="nav-link" id="banType">Ban</a>
-            </li>
-            <li class="nav-item pe-1">
-              <a href="javascript:;" class="nav-link" id="kickType">Kick</a>
-            </li>
-            <li class="nav-item pe-1">
-              <a href="javascript:;" class="nav-link" id="muteType">Mute</a>
-            </li>
-            <li class="nav-item pe-3">
-              <a href="javascript:;" class="nav-link" id="warnType">Warn</a>
-            </li>
-          </ul>
-          <!-- <button class="version-btn ps-4"><i class="fab fa-github fs-4"></i></button> -->
-        </div>
-      </div>
-    </nav>
 
-    <!-- Punishments -->
-    <section class=" text-light my-5 p-lg-0 pt-lg-5 text-center text-sm-start section-darker">
-      <div class="container">
+        <button class="navbar-toggle-btn-mobile d-lg-none" id="navbar-toggler" type="button" data-bs-toggle="collapse"
+                data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
+                aria-label="Toggle navigation">
+            <i class="fas fa-sliders-h"></i>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                <li class="nav-item navbar-active pe-1">
+                    <a href="javascript:;" class="nav-link" id="banType">Ban</a>
+                </li>
+                <li class="nav-item pe-1">
+                    <a href="javascript:;" class="nav-link" id="kickType">Kick</a>
+                </li>
+                <li class="nav-item pe-1">
+                    <a href="javascript:;" class="nav-link" id="muteType">Mute</a>
+                </li>
+                <li class="nav-item pe-3">
+                    <a href="javascript:;" class="nav-link" id="warnType">Warn</a>
+                </li>
+            </ul>
+            <!-- <button class="version-btn ps-4"><i class="fab fa-github fs-4"></i></button> -->
+        </div>
+    </div>
+</nav>
+
+<!-- Punishments -->
+<section class=" text-light my-5 p-lg-0 pt-lg-5 text-center text-sm-start section-darker">
+    <div class="container">
         <!-- Info Text -->
         <div class="d-flex justify-content-start">
-          <h1 class="fs-2 category-text pb-1" id="type-stats">
-              <p id="type-stats-text">Bans</p>
-          </h1>
+            <h1 class="fs-2 category-text pb-1" id="type-stats">
+                <p id="type-stats-text">Bans</p>
+            </h1>
         </div>
-          <!-- Bootstrap Spinner -->
-          <div class="d-flex justify-content-center spinner">
-              <div id="punishments-spinner" class="spinner-border m-5" role="status">
-                  <span class="sr-only">Loading...</span>
-              </div>
-          </div>
+        <!-- Bootstrap Spinner -->
+        <div class="d-flex justify-content-center spinner">
+            <div id="punishments-spinner" class="spinner-border m-5" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
         <!-- Punishment List -->
         <div id="punishments">
-          <!-- -->
+            <!-- -->
             <!-- 0 -->
             <div id="punishments-0">
                 <div class="row align-items-center p-3 flex-nowrap">
@@ -96,6 +98,48 @@
                         <span id="status-badge-0" class="fw-medium">Length</span>
                     </div>
                     <div id="line-below-0" class="col-auto"></div>
+                </div>
+                <div class="row punishment-info flex-nowrap">
+                    <div class="col">
+                        <div class="collapse punishment-0-collapse-0" id="punishments-0-collapse-0-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-start-date-0">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse punishment-0-collapse-1" id="punishments-0-collapse-1-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-0">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collapse punishment-0-collapse-2" id="punishments-0-collapse-2-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-0">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                    <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                                data-bs-target="punishment-0-collapse-0, punishment-0-collapse-1, punishment-0-collapse-2"
+                                aria-expanded="false"
+                                aria-controls="punishments-0-collapse-0-arial punishments-0-collapse-1-arial punishments-0-collapse-1-arial">
+                            <i class="fa fa-info-circle fa-w-16"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div id="punishments-1">
@@ -124,6 +168,48 @@
                     </div>
                     <div id="line-below-1" class="col-auto"></div>
                 </div>
+                <div class="row punishment-info flex-nowrap">
+                    <div class="col">
+                        <div class="collapse punishment-1-collapse-0" id="punishments-1-collapse-0-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-start-date-1">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse punishment-1-collapse-1" id="punishments-1-collapse-1-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-1">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collapse punishment-1-collapse-2" id="punishments-1-collapse-2-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-1">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                    <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                                data-bs-target="punishment-1-collapse-0, punishment-1-collapse-1, punishment-1-collapse-2"
+                                aria-expanded="false"
+                                aria-controls="punishments-1-collapse-0-arial punishments-1-collapse-1-arial punishments-1-collapse-1-arial">
+                            <i class="fa fa-info-circle fa-w-16"></i>
+                        </button>
+                    </div>
+                </div>
             </div>
             <div id="punishments-2">
                 <div class="row align-items-center p-3 flex-nowrap">
@@ -150,6 +236,48 @@
                         <span id="status-badge-2" class="fw-medium">Length</span>
                     </div>
                     <div id="line-below-2" class="col-auto"></div>
+                </div>
+                <div class="row punishment-info flex-nowrap">
+                    <div class="col">
+                        <div class="collapse punishment-2-collapse-0" id="punishments-2-collapse-0-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-start-date-2">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse punishment-2-collapse-1" id="punishments-2-collapse-1-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-2">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collapse punishment-2-collapse-2" id="punishments-2-collapse-2-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-2">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                    <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                                data-bs-target="punishment-2-collapse-0, punishment-2-collapse-1, punishment-2-collapse-2"
+                                aria-expanded="false"
+                                aria-controls="punishments-2-collapse-0-arial punishments-2-collapse-1-arial punishments-2-collapse-1-arial">
+                            <i class="fa fa-info-circle fa-w-16"></i>
+                        </button>
+                    </div>
                 </div>
             </div>
             <div id="punishments-3">
@@ -178,6 +306,48 @@
                     </div>
                     <div id="line-below-3" class="col-auto"></div>
                 </div>
+                <div class="row punishment-info flex-nowrap">
+                    <div class="col">
+                        <div class="collapse punishment-3-collapse-0" id="punishments-3-collapse-0-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-start-date-3">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse punishment-0-collapse-1" id="punishments-3-collapse-1-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-3">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collapse punishment-0-collapse-2" id="punishments-3-collapse-2-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-3">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                    <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                                data-bs-target="punishment-3-collapse-0, punishment-3-collapse-1, punishment-3-collapse-2"
+                                aria-expanded="false"
+                                aria-controls="punishments-3-collapse-0-arial punishments-3-collapse-1-arial punishments-3-collapse-1-arial">
+                            <i class="fa fa-info-circle fa-w-16"></i>
+                        </button>
+                    </div>
+                </div>
             </div>
             <div id="punishments-4">
                 <div class="row align-items-center p-3 flex-nowrap">
@@ -205,56 +375,139 @@
                     </div>
                     <div id="line-below-4" class="col-auto"></div>
                 </div>
+                <div class="row punishment-info flex-nowrap">
+                    <div class="col">
+                        <div class="collapse punishment-4-collapse-0" id="punishments-4-collapse-0-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-start-date-4">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse punishment-4-collapse-1" id="punishments-4-collapse-1-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-4">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collapse punishment-4-collapse-2" id="punishments-4-collapse-2-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-4">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                    <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                                data-bs-target="punishment-4-collapse-0, punishment-4-collapse-1, punishment-4-collapse-2"
+                                aria-expanded="false"
+                                aria-controls="punishments-4-collapse-0-arial punishments-4-collapse-1-arial punishments-4-collapse-1-arial">
+                            <i class="fa fa-info-circle fa-w-16"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div id="punishments-5">
+                <div class="row align-items-center p-3 flex-nowrap">
+                    <div id="line-upper-5" class="col-auto"></div>
+                    <div class="col-auto">
+                        <img id="first-uuid-5" src="./images/Tw8t.png">
+                    </div>
+                    <div class="col">
+                        <p class="fs-5 mb-0">Offender</p>
+                        <p id="offender-5">Offender-0</p>
+                    </div>
+                    <div class="col-auto">
+                        <img id="second-uuid-5" src="./images/Dorpw.png">
+                    </div>
+                    <div class="col">
+                        <p class="fs-5 mb-0">Staff</p>
+                        <p id="operator-5">Operator-0</p>
+                    </div>
+                    <div class="col">
+                        <div class="fs-5 mb-0">Reason</div>
+                        <p id="reason-5">Cheating</p>
+                    </div>
+                    <div class="col">
+                        <span id="status-badge-5" class="fw-medium">Length</span>
+                    </div>
+                    <div id="line-below-5" class="col-auto"></div>
+                </div>
+                <div class="row punishment-info flex-nowrap">
+                    <div class="col">
+                        <div class="collapse punishment-5-collapse-0" id="punishments-5-collapse-0-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-start-date-5">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse punishment-5-collapse-1" id="punishments-5-collapse-1-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-5">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse collapse punishment-5-collapse-2" id="punishments-5-collapse-2-arial">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-5">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                    <div class="d-flex justify-content-center">
+                        <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                                data-bs-target="punishment-5-collapse-0, punishment-5-collapse-1, punishment-5-collapse-2"
+                                aria-expanded="false"
+                                aria-controls="punishments-5-collapse-0-arial punishments-5-collapse-1-arial punishments-5-collapse-1-arial">
+                            <i class="fa fa-info-circle fa-w-16"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div id="nothing-to-show" class="text-center p-5">
+                <p class="fw-medium fs-5 mb-0">Nothing to show for now</p>
             </div>
         </div>
-          <div id="punishments-5">
-              <div class="row align-items-center p-3 flex-nowrap">
-                  <div id="line-upper-5" class="col-auto"></div>
-                  <div class="col-auto">
-                      <img id="first-uuid-5" src="./images/Tw8t.png">
-                  </div>
-                  <div class="col">
-                      <p class="fs-5 mb-0">Offender</p>
-                      <p id="offender-5">Offender-0</p>
-                  </div>
-                  <div class="col-auto">
-                      <img id="second-uuid-5" src="./images/Dorpw.png">
-                  </div>
-                  <div class="col">
-                      <p class="fs-5 mb-0">Staff</p>
-                      <p id="operator-5">Operator-0</p>
-                  </div>
-                  <div class="col">
-                      <div class="fs-5 mb-0">Reason</div>
-                      <p id="reason-5">Cheating</p>
-                  </div>
-                  <div class="col">
-                      <span id="status-badge-5" class="fw-medium">Length</span>
-                  </div>
-                  <div id="line-below-5" class="col-auto"></div>
-              </div>
-          </div>
-      </div>
-        <div id="nothing-to-show" class="text-center p-5">
-            <p class="fw-medium fs-5 mb-0">Nothing to show for now</p>
-        </div>
-        </div>
         <div class="d-flex justify-content-center">
-          <button class="previous-btn p-2 mx-1" id="prevBtn">Previous</button>
-          <input class="page-count text-center" type="number" id="pageCount" name="page-count" min="1" max="999" size="4">
-          <button class="next-btn p-2 mx-1" id="nextBtn">Next</button>
-          <div id="view-punishments"></div>
+            <button class="previous-btn p-2 mx-1" id="prevBtn">Previous</button>
+            <input class="page-count text-center" type="number" id="pageCount" name="page-count" min="1" max="999"
+                   size="4">
+            <button class="next-btn p-2 mx-1" id="nextBtn">Next</button>
+            <div id="view-punishments"></div>
         </div>
-      </div>
-    </section>
-    
+    </div>
+</section>
 
-    <!-- Footer -->
-    <footer class="footer py-3">
-        <div class="container d-flex justify-content-center align-items-center">
-          <p class="m-0 footer-text">Made with <i class="fas fa-heart heart-icon mx-1"></i></p>
-        </div>
-    </footer>
-    
+
+<!-- Footer -->
+<footer class="footer py-3">
+    <div class="container d-flex justify-content-center align-items-center">
+        <p class="m-0 footer-text">Made with <i class="fas fa-heart heart-icon mx-1"></i></p>
+    </div>
+</footer>
+
 </body>
 </html>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -148,17 +148,17 @@ $(document).ready(function () {
 
     function setPunishmentStyle(length, row) {
         if (length === "Permanent") {
-            $(`#line-upper-${row}`).addClass('permanent-line');
+            $(`#line-upper-${row}`).addClass('permanent-line-left');
             $(`#status-badge-${row}`).addClass('permanent');
-            $(`#line-below-${row}`).addClass('permanent-line');
+            $(`#line-below-${row}`).addClass('permanent-line-right');
         } else if (length === "Active") {
-            $(`#line-upper-${row}`).addClass('active-line');
+            $(`#line-upper-${row}`).addClass('active-line-left');
             $(`#status-badge-${row}`).addClass('active');
-            $(`#line-below-${row}`).addClass('active-line');
+            $(`#line-below-${row}`).addClass('active-line-right');
         } else {
-            $(`#line-upper-${row}`).addClass('expired-line');
+            $(`#line-upper-${row}`).addClass('expired-line-left');
             $(`#status-badge-${row}`).addClass('expired');
-            $(`#line-below-${row}`).addClass('expired-line');
+            $(`#line-below-${row}`).addClass('expired-line-right');
         }
     }
 
@@ -204,6 +204,7 @@ $(document).ready(function () {
         // Since we have 6 pre-defined html well objects, we need to hide them all.
         for (let i = 0; i < 6; i++) {
             $(`#punishments-${i}`).hide();
+            $(`#punishments-info-${i}`).hide();
         }
 
         updatePageCount();
@@ -238,6 +239,7 @@ $(document).ready(function () {
             typeStats.show();
             for (let i = 0; i < rowCount; i++) {
                 $(`#punishments-${i}`).show();
+                $(`#punishments-info-${i}`).show();
             }
         }).catch(e => {
             console.log(e);

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -139,17 +139,17 @@ $(document).ready(function () {
 
     function setPunishmentStyle(length, row) {
         if (length === "Permanent") {
-            $(`#line-upper-${rowCount}`).addClass('permanent-line');
-            $(`#status-badge-${rowCount}`).addClass('permanent');
-            $(`#line-below-${rowCount}`).addClass('permanent-line');
+            $(`#line-upper-${row}`).addClass('permanent-line');
+            $(`#status-badge-${row}`).addClass('permanent');
+            $(`#line-below-${row}`).addClass('permanent-line');
         } else if (length === "Active") {
-            $(`#line-upper-${rowCount}`).addClass('active-line');
-            $(`#status-badge-${rowCount}`).addClass('active');
-            $(`#line-below-${rowCount}`).addClass('active-line');
+            $(`#line-upper-${row}`).addClass('active-line');
+            $(`#status-badge-${row}`).addClass('active');
+            $(`#line-below-${row}`).addClass('active-line');
         } else {
-            $(`#line-upper-${rowCount}`).addClass('expired-line');
-            $(`#status-badge-${rowCount}`).addClass('expired');
-            $(`#line-below-${rowCount}`).addClass('expired-line');
+            $(`#line-upper-${row}`).addClass('expired-line');
+            $(`#status-badge-${row}`).addClass('expired');
+            $(`#line-below-${row}`).addClass('expired-line');
         }
     }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -162,7 +162,7 @@ $(document).ready(function () {
         }
     }
 
-    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row, startDate, expirationDate, timeUntilExpiration) {
+    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row, startDate, expirationDate, timeUntilExpirationDate, length) {
         $(`#first-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${victimUUID}`);
         $(`#offender-${row}`).text(`${victimUsername}`);
         $(`#second-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${operatorUUID}`);
@@ -171,7 +171,8 @@ $(document).ready(function () {
 
         $(`#punishment-start-date-${row}`).text(`${startDate}`);
         $(`#punishment-end-date-${row}`).text(`${expirationDate}`);
-        $(`#punishment-expire-date-${row}`).text(`${timeUntilExpiration}`);
+        $(`#punishment-length-${row}`).text(`${timeUntilExpirationDate}`);
+        $(`#punishment-expire-date-${row}`).text(`${timeUntilExpirationDate}`);
     }
 
     function setMorePages(morePages) {
@@ -246,14 +247,17 @@ $(document).ready(function () {
                 }
 
                 let expirationDate = data.punishments[key].endDate;
+                let isActive = data.punishments[key].active;
                 let timeUntilExpiration;
                 if (expirationDate === "Never") {
                     timeUntilExpiration = "Never";
+                } else if (isActive === false) {
+                    timeUntilExpiration = "Expired/Revoked";
                 } else {
                     timeUntilExpiration = calculateExpirationDate(expirationDate);
                 }
 
-                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount, data.punishments[key].startDate, data.punishments[key].endDate, timeUntilExpiration);
+                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount, data.punishments[key].startDate, data.punishments[key].endDate, timeUntilExpiration, data.punishments[key].punishmentLength);
                 rowCount++;
             }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -162,18 +162,18 @@ $(document).ready(function () {
         }
     }
 
-    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row, startDate, expirationDate, timeUntilExpirationDate, length, label) {
+    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, startDate, expirationDate, timeUntilExpirationDate, length, label, row) {
         $(`#first-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${victimUUID}`);
         $(`#offender-${row}`).text(`${victimUsername}`);
         $(`#second-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${operatorUUID}`);
         $(`#operator-${row}`).text(`${operatorUsername}`);
         $(`#reason-${row}`).text(`${reason}`);
-        $(`#status-badge-${row}`).text(`${label}`);
 
         $(`#punishment-start-date-${row}`).text(`${startDate}`);
         $(`#punishment-end-date-${row}`).text(`${expirationDate}`);
-        $(`#punishment-length-${row}`).text(`${timeUntilExpirationDate}`);
-        $(`#punishment-expire-date-${row}`).text(`${length}`);
+        $(`#punishment-length-${row}`).text(`${length}`);
+        $(`#punishment-expire-date-${row}`).text(`${timeUntilExpirationDate}`);
+        $(`#status-badge-${row}`).text(`${label}`);
     }
 
     function setMorePages(morePages) {
@@ -239,7 +239,7 @@ $(document).ready(function () {
         // We actually got data!
         getWithAsyncFetch(`/punishments/${type}/${page}`).then(data => {
             let rowCount = 0;
-            for (const key in data.punishments) {
+            for (let key in data.punishments) {
                 setPunishmentStyle(data.punishments[key].label, rowCount);
 
                 let operatorUUID = data.punishments[key].operatorUuid;
@@ -258,7 +258,7 @@ $(document).ready(function () {
                     timeUntilExpiration = calculateExpirationDate(expirationDate);
                 }
 
-                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount, data.punishments[key].startDate, data.punishments[key].endDate, timeUntilExpiration, data.punishments[key].punishmentLength, data.punishments[key].label);
+                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, data.punishments[key].startDate, data.punishments[key].endDate, timeUntilExpiration, data.punishments[key].punishmentLength, data.punishments[key].label, rowCount);
                 rowCount++;
             }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -16,34 +16,40 @@ $(document).ready(function () {
         return json;
     }
 
+    function setTypeText(type) {
+        let typeText;
+
+        switch (type) {
+            case "ban":
+                typeText = "Bans";
+                break;
+
+            case "mute":
+                typeTexts = "Mutes";
+                break;
+
+            case "kick":
+                typeText = "Kicks";
+                break;
+
+            case "warn":
+                typeText = "Warns";
+                break;
+        }
+
+        return typeText;
+    }
+
     function fetchTypeStats(type) {
-        let typeText = "Punishment type";
-        let dataStats = "0";
+        let typeText;
+
+        typeText = setTypeText(type);
 
         getWithAsyncFetch(`/stats/${type}`).then(data => {
-            switch (data.type) {
-                case "ban":
-                    typeText = "Bans";
-                    break;
-
-                    case "mute":
-                        typeText = "Mutes";
-                        break;
-
-                    case "kick":
-                        typeText = "Kicks";
-                        break;
-
-                    case "warn":
-                        typeText = "Warns";
-                        break;
-                }
-                dataStats = data.stats;
+            $('#type-stats-text').text(`${typeText} (${data.stats})`);
         }).catch(e => {
             console.log(e)
         });
-
-        $('#type-stats-text').text(`${typeText} (${dataStats})`);
     }
 
     function updatePageCount() {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -162,14 +162,15 @@ $(document).ready(function () {
         }
     }
 
-    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row) {
+    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row, startDate, expirationDate) {
         $(`#first-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${victimUUID}`);
         $(`#offender-${row}`).text(`${victimUsername}`);
         $(`#second-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${operatorUUID}`);
         $(`#operator-${row}`).text(`${operatorUsername}`);
         $(`#reason-${row}`).text(`${reason}`);
 
-        $(`#punishment-start-date-${row}`).text()
+        $(`#punishment-start-date-${row}`).text(`${startDate}`);
+        $(`#punishment-end-date-${row}`).text(`${expirationDate}`);
     }
 
     function setMorePages(morePages) {
@@ -221,7 +222,12 @@ $(document).ready(function () {
                     operatorUUID = "console";
                 }
 
-                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount);
+                let punishmentExpirationDate = data.punishments[key].end;
+                if (punishmentExpirationDate === 0) {
+                    punishmentExpirationDate = "Never";
+                }
+
+                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount, data.punishments[key].start, punishmentExpirationDate);
                 rowCount++;
             }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -162,17 +162,18 @@ $(document).ready(function () {
         }
     }
 
-    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row, startDate, expirationDate, timeUntilExpirationDate, length) {
+    function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, row, startDate, expirationDate, timeUntilExpirationDate, length, label) {
         $(`#first-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${victimUUID}`);
         $(`#offender-${row}`).text(`${victimUsername}`);
         $(`#second-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${operatorUUID}`);
         $(`#operator-${row}`).text(`${operatorUsername}`);
         $(`#reason-${row}`).text(`${reason}`);
+        $(`#status-badge-${row}`).text(`${label}`);
 
         $(`#punishment-start-date-${row}`).text(`${startDate}`);
         $(`#punishment-end-date-${row}`).text(`${expirationDate}`);
         $(`#punishment-length-${row}`).text(`${timeUntilExpirationDate}`);
-        $(`#punishment-expire-date-${row}`).text(`${timeUntilExpirationDate}`);
+        $(`#punishment-expire-date-${row}`).text(`${length}`);
     }
 
     function setMorePages(morePages) {
@@ -257,7 +258,7 @@ $(document).ready(function () {
                     timeUntilExpiration = calculateExpirationDate(expirationDate);
                 }
 
-                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount, data.punishments[key].startDate, data.punishments[key].endDate, timeUntilExpiration, data.punishments[key].punishmentLength);
+                setRowData(data.punishments[key].victimUuid, data.punishments[key].victimUsername, operatorUUID, data.punishments[key].operatorUsername, data.punishments[key].reason, rowCount, data.punishments[key].startDate, data.punishments[key].endDate, timeUntilExpiration, data.punishments[key].punishmentLength, data.punishments[key].label);
                 rowCount++;
             }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -168,6 +168,8 @@ $(document).ready(function () {
         $(`#second-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${operatorUUID}`);
         $(`#operator-${row}`).text(`${operatorUsername}`);
         $(`#reason-${row}`).text(`${reason}`);
+
+        $(`#punishment-start-date-${row}`).text()
     }
 
     function setMorePages(morePages) {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -162,6 +162,32 @@ $(document).ready(function () {
         }
     }
 
+    // Look this isn't the cleanest, but we do however have to remove the previous state.
+    function removePreviousClasses(length, row) {
+        if (length === "Permanent") {
+            $(`#line-upper-${row}`).removeClass('active-line-left');
+            $(`#line-upper-${row}`).removeClass('expired-line-left');
+            $(`#status-badge-${row}`).removeClass('active');
+            $(`#status-badge-${row}`).removeClass('expired');
+            $(`#line-below-${row}`).removeClass('active-line-right');
+            $(`#line-below-${row}`).removeClass('expired-line-right');
+        } else if (length === "Active") {
+            $(`#line-upper-${row}`).removeClass('permanent-line-left');
+            $(`#line-upper-${row}`).removeClass('expired-line-left');
+            $(`#status-badge-${row}`).removeClass('permanent');
+            $(`#status-badge-${row}`).removeClass('expired');
+            $(`#line-below-${row}`).removeClass('permanent-line-right');
+            $(`#line-below-${row}`).removeClass('expired-line-right');
+        } else {
+            $(`#line-upper-${row}`).removeClass('permanent-line-left');
+            $(`#line-upper-${row}`).removeClass('active-line-left');
+            $(`#status-badge-${row}`).removeClass('permanent');
+            $(`#status-badge-${row}`).removeClass('active');
+            $(`#line-below-${row}`).removeClass('permanent-line-right');
+            $(`#line-below-${row}`).removeClass('active-line-right');
+        }
+    }
+
     function setRowData(victimUUID, victimUsername, operatorUUID, operatorUsername, reason, startDate, expirationDate, timeUntilExpirationDate, length, label, row) {
         $(`#first-uuid-${row}`).attr('src', `https://visage.surgeplay.com/face/55/${victimUUID}`);
         $(`#offender-${row}`).text(`${victimUsername}`);
@@ -206,7 +232,7 @@ $(document).ready(function () {
         const utc1 = Date.UTC(dateObject.getFullYear(), dateObject.getMonth(), dateObject.getDate());
         const utc2 = Date.UTC(dateToday.getFullYear(), dateToday.getMonth(), dateToday.getDate());
 
-        const differenceDays = Math.floor(utc2 - utc1);
+        const differenceDays = Math.floor(utc1 - utc2);
 
         let diffDays = Math.floor(differenceDays / _MS_PER_DAY); // days
         let diffHrs = Math.floor((differenceDays % _MS_PER_DAY) / _MS_PER_DAY); // hours
@@ -240,6 +266,7 @@ $(document).ready(function () {
         getWithAsyncFetch(`/punishments/${type}/${page}`).then(data => {
             let rowCount = 0;
             for (let key in data.punishments) {
+                removePreviousClasses(data.punishments[key].label, rowCount);
                 setPunishmentStyle(data.punishments[key].label, rowCount);
 
                 let operatorUUID = data.punishments[key].operatorUuid;

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -25,7 +25,7 @@ $(document).ready(function () {
                 break;
 
             case "mute":
-                typeTexts = "Mutes";
+                typeText = "Mutes";
                 break;
 
             case "kick":

--- a/frontend/test.html
+++ b/frontend/test.html
@@ -88,16 +88,51 @@
               <div class="fs-5 mb-0">Reason</div>
               <p>Hacking & Spamming</p>
             </div>
-            <div class="col">
+            <div class="col-auto">
               <span class="permanent fw-medium">Permanent</span>
             </div>
-            <div class="col-auto permanent-line"></div>
+            <div class="col-auto permanent-line-right"></div>
           </div>
-          <div class="row align-items-center flex-nowrap punishment-row">
-            <div class="test collapse" id="collapseExample">
-              <div class="p-2 d-flex justify-content-center"><p>Additional Info...</p></div>
+
+            <div class="row punishment-info flex-nowrap">
+                <div class="col">
+                    <div class="collapse multi-collapse" id="multiCollapseExample1">
+                        <div class="card text-bg-dark mb-3 text-center">
+                            <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                            <div class="card-body">
+                                <p id="punishment-start-date-0">2025.04.27</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                        <div class="collapse multi-collapse" id="multiCollapseExample2">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-end-date-0">2025.04.27</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="collapse multi-collapse" id="multiCollapseExample3">
+                            <div class="card text-bg-dark mb-3 text-center">
+                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                                <div class="card-body">
+                                    <p id="punishment-expire-date-0">2025.04.27</p>
+                                </div>
+                            </div>
+                    </div>
+                    </div>
             </div>
-          </div>
+            <div class="row align-items-center p-3 flex-nowrap punishment-row">
+                <div class="d-flex justify-content-center">
+                    <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse" data-bs-target=".multi-collapse" aria-expanded="false" aria-controls="multiCollapseExample1 multiCollapseExample2 multiCollapseExample3">
+                        <i class="fa fa-info-circle fa-w-16"></i>
+                    </button>
+                </div>
+            </div>
           
   
         </div>

--- a/frontend/test.html
+++ b/frontend/test.html
@@ -69,7 +69,7 @@
         <div id="punishments">
 
           <div class="row align-items-center p-3 flex-nowrap punishment-row">
-            <div class="col-auto permanent-line"></div>
+            <div class="col-auto permanent-line-left"></div>
             <div class="col-auto">
               <img src="https://visage.surgeplay.com/face/55/98015c8810d941d3b87bef1efe964c1c">
             </div>
@@ -96,39 +96,42 @@
 
             <div class="row punishment-info flex-nowrap">
                 <div class="col">
-                    <div class="collapse multi-collapse" id="multiCollapseExample1">
+                    <div class="collapse punishment-1-collapse-0" id="punishments-1-collapse-0-arial">
                         <div class="card text-bg-dark mb-3 text-center">
                             <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
                             <div class="card-body">
-                                <p id="punishment-start-date-0">2025.04.27</p>
+                                <p id="punishment-start-date-1">2025.04.27</p>
                             </div>
                         </div>
                     </div>
                 </div>
                 <div class="col">
-                        <div class="collapse multi-collapse" id="multiCollapseExample2">
-                            <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
-                                <div class="card-body">
-                                    <p id="punishment-end-date-0">2025.04.27</p>
-                                </div>
+                    <div class="collapse punishment-1-collapse-1" id="punishments-1-collapse-1-arial">
+                        <div class="card text-bg-dark mb-3 text-center">
+                            <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                            <div class="card-body">
+                                <p id="punishment-end-date-1">2025.04.27</p>
                             </div>
                         </div>
                     </div>
-                    <div class="col">
-                        <div class="collapse multi-collapse" id="multiCollapseExample3">
-                            <div class="card text-bg-dark mb-3 text-center">
-                                <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
-                                <div class="card-body">
-                                    <p id="punishment-expire-date-0">2025.04.27</p>
-                                </div>
+                </div>
+                <div class="col">
+                    <div class="collapse collapse punishment-1-collapse-2-arial" id="punishment-1-collapse-2">
+                        <div class="card text-bg-dark mb-3 text-center">
+                            <h5 class="card-header fs-5 mb-0">Punishment start date:</h5>
+                            <div class="card-body">
+                                <p id="punishment-expire-date-1">2025.04.27</p>
                             </div>
+                        </div>
                     </div>
-                    </div>
+                </div>
             </div>
             <div class="row align-items-center p-3 flex-nowrap punishment-row">
                 <div class="d-flex justify-content-center">
-                    <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse" data-bs-target=".multi-collapse" aria-expanded="false" aria-controls="multiCollapseExample1 multiCollapseExample2 multiCollapseExample3">
+                    <button class="btn btn-primary punishment-button" type="button" data-bs-toggle="collapse"
+                            data-bs-target="#punishment-1-collapse-0, #punishment-1-collapse-1, #punishment-1-collapse-2"
+                            aria-expanded="false"
+                            aria-controls="punishments-1-collapse-0-arial punishments-1-collapse-1-arial punishments-1-collapse-2-arial">
                         <i class="fa fa-info-circle fa-w-16"></i>
                     </button>
                 </div>


### PR DESCRIPTION
This PR implements the highly anticipated feature described in #7 . The punishments now show the
- start date,
- expiration date,
- length,
- and the time until the punishment expires.

As it can be seen in the following screenshot:
![image](https://github.com/Dimitri-Bit/Liberty-Bans-Web/assets/67807644/e6d2bf69-3df5-4502-b5c8-4081dccc034f)


Additionally, this PR fixes issues found in the html code, as well as issues found in CSS. This PR is built on top of #21 , so please don't merge this unless that PR has been proceeded.

This feature has been a lot of fun to work on. Currently, there are two things I'd like to possibly address before this gets merged:
- Currently, due to how we populate HTML values, the elements so called "collapse"s aren't getting closed on page navigation. This can be worked around by adding an additional function to the navigation buttons, but I decided not to touch them.
- In my opinion, the current layout, where we have a punishment row + information button + the hidden "collapse" element doesn't look good. Thankfully, by editing the html and css code, the design can be changed at any time, so if someone thinks of a better approach, I'm happy to adjust! Otherwise, if you think this design is sufficient, feel free to merge the PR.

Of course, none of these concerns are blocking, but I just thought to mention. Enjoy! :p