### PR TITLE
Add missing API parameter.

### DIFF
--- a/src/main/java/me/dimitri/libertyweb/utils/ObjectMapper.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/ObjectMapper.java
@@ -2,7 +2,6 @@ package me.dimitri.libertyweb.utils;
 
 import me.dimitri.libertyweb.api.LibertyWeb;
 import me.dimitri.libertyweb.model.WebPunishment;
-import space.arim.libertybans.api.AddressVictim;
 import space.arim.libertybans.api.PlayerOperator;
 import space.arim.libertybans.api.PlayerVictim;
 import space.arim.libertybans.api.punish.Punishment;

--- a/src/main/java/me/dimitri/libertyweb/utils/ObjectMapper.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/ObjectMapper.java
@@ -2,6 +2,7 @@ package me.dimitri.libertyweb.utils;
 
 import me.dimitri.libertyweb.api.LibertyWeb;
 import me.dimitri.libertyweb.model.WebPunishment;
+import space.arim.libertybans.api.AddressVictim;
 import space.arim.libertybans.api.PlayerOperator;
 import space.arim.libertybans.api.PlayerVictim;
 import space.arim.libertybans.api.punish.Punishment;
@@ -32,6 +33,7 @@ public class ObjectMapper {
                 webPunishment.setOperatorUsername("Console");
             }
 
+            webPunishment.setActive(getActiveSate(punishment));
             webPunishment.setLabel(getLabel(punishment));
             webPunishment.setReason(punishment.getReason());
             webPunishment.setPunishmentLength(getPunishmentLength(punishment));
@@ -57,6 +59,10 @@ public class ObjectMapper {
             return "Permanent";
         }
         return "Unknown";
+    }
+
+    private static boolean getActiveSate(Punishment punishment) {
+        return punishment.isExpired();
     }
 
     private static String getPunishmentLength(Punishment punishment) {

--- a/src/main/java/me/dimitri/libertyweb/utils/ObjectMapper.java
+++ b/src/main/java/me/dimitri/libertyweb/utils/ObjectMapper.java
@@ -61,7 +61,7 @@ public class ObjectMapper {
     }
 
     private static boolean getActiveSate(Punishment punishment) {
-        return punishment.isExpired();
+        return !punishment.isExpired();
     }
 
     private static String getPunishmentLength(Punishment punishment) {


### PR DESCRIPTION
It appears that in the current API the "active" parameter wasn't being set, so it defaulted to false for every response. This PR fixes this by adding a value to the parameter.